### PR TITLE
Prevent the loop that keeps the Iroh-connection alive from burning 100%

### DIFF
--- a/crates/remote_server/src/unix/p2p.rs
+++ b/crates/remote_server/src/unix/p2p.rs
@@ -119,7 +119,9 @@ pub(crate) fn execute(persist: bool, mut persist_at: Option<PathBuf>) -> Result<
             println!("TICKET: {}", ticket);
 
             // TODO: better shutdown
-            loop {}
+            loop {
+                tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+            }
         })
         .detach();
 


### PR DESCRIPTION
Release Notes:

- Prevent the loop that keeps the Iroh-connection alive from burning 100% of the CPU time of one core.